### PR TITLE
fix: add MiMo template and _MODEL_NAME env vars for status bar display

### DIFF
--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -67,6 +67,16 @@ const PROVIDER_TEMPLATES: ProviderTemplateConfig[] = [
     sonnetModel: 'MiniMax-M2.7',
     opusModel: 'MiniMax-M2.7',
   },
+  {
+    name: 'mimo',
+    label: 'Xiaomi MiMo',
+    requiresApiKey: true,
+    baseUrl: 'https://token-plan-cn.xiaomimimo.com/anthropic',
+    haikuModel: 'mimo-v2.5-pro',
+    sonnetModel: 'mimo-v2.5-pro',
+    opusModel: 'mimo-v2.5-pro',
+    aliases: ['xiaomi'],
+  },
 ];
 
 const TEMPLATE_ALIASES = new Map<string, ProviderTemplateName>();
@@ -255,12 +265,15 @@ function applyTemplateOverrides(
 
   if (template.haikuModel) {
     env.ANTHROPIC_DEFAULT_HAIKU_MODEL = template.haikuModel;
+    env.ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME = template.haikuModel;
   }
   if (template.sonnetModel) {
     env.ANTHROPIC_DEFAULT_SONNET_MODEL = template.sonnetModel;
+    env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME = template.sonnetModel;
   }
   if (template.opusModel) {
     env.ANTHROPIC_DEFAULT_OPUS_MODEL = template.opusModel;
+    env.ANTHROPIC_DEFAULT_OPUS_MODEL_NAME = template.opusModel;
   }
 
   parsed.env = env;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface ActiveProfileStatus {
   exists: boolean;
 }
 
-export type ProviderTemplateName = 'anthropic' | 'moonshot' | 'zai' | 'minimax';
+export type ProviderTemplateName = 'anthropic' | 'moonshot' | 'zai' | 'minimax' | 'mimo';
 
 export interface CreateProfileOptions {
   template?: ProviderTemplateName;


### PR DESCRIPTION
## Summary

- Add Xiaomi MiMo as a provider template (`mimo` / `xiaomi`)
- Set `ANTHROPIC_DEFAULT_*_MODEL_NAME` env vars in `applyTemplateOverrides` so the Claude Code status bar shows the actual proxy model name instead of "Opus 4.7"

## Problem

When switching to a non-Anthropic provider (e.g. MiMo), cc-switch sets `ANTHROPIC_DEFAULT_OPUS_MODEL` etc. but not the `_MODEL_NAME` variants. Claude Code uses the `_MODEL_NAME` vars for the status bar display, so it falls back to showing the internal Anthropic model name even though API calls go to the proxy.

## Changes

**`src/types.ts`**: Add `'mimo'` to `ProviderTemplateName` union

**`src/profiles.ts`**:
1. Add MiMo template:
   - Base URL: `https://token-plan-cn.xiaomimimo.com/anthropic`
   - Model: `mimo-v2.5-pro` for all slots
   - Aliases: `xiaomi`

2. In `applyTemplateOverrides`, also set:
   - `ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME`
   - `ANTHROPIC_DEFAULT_SONNET_MODEL_NAME`
   - `ANTHROPIC_DEFAULT_OPUS_MODEL_NAME`

Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Xiaomi MiMo as a new supported AI provider with multiple model variants (Haiku, Sonnet, and Opus) now available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aravhawk/cc-switch/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->